### PR TITLE
Add offline prefix to notification message when the run is offline

### DIFF
--- a/src/dispatcher/dispatcher.rs
+++ b/src/dispatcher/dispatcher.rs
@@ -52,7 +52,7 @@ impl Dispatcher {
             let live_indicator = if self.response.user.live_account.is_some() {
                 String::from(":red_circle:")
             } else {
-                String::from("")
+                String::from("Offline")
             };
 
             let event_type = match get_event_type(&last_event) {


### PR DESCRIPTION
Got jebaited by this a bunch of times.. Live messages do have a :red_circle: but might still be nice having an offline indicator?

![image](https://github.com/user-attachments/assets/7933bc76-694d-4804-a447-7f0d5be534f7)
