### PR TITLE
Add live indicator back to notification message

### DIFF
--- a/src/dispatcher/pace_event.rs
+++ b/src/dispatcher/pace_event.rs
@@ -75,6 +75,12 @@ pub async fn handle_pace_event(ctx: Arc<Context>, response: &Response, live_link
             );
         }
 
+        let live_indicator = if response.user.live_account.is_some() {
+            "🔴"
+        } else {
+            "⚪"
+        };
+
         let mut item_data_content = String::new();
 
         match &response.item_data {
@@ -117,7 +123,8 @@ pub async fn handle_pace_event(ctx: Arc<Context>, response: &Response, live_link
             },
         }
         let metadata = format!(
-            "{} - {} {}", 
+            "{} {} - {} {}", 
+            live_indicator,
             format_time(last_event.igt as u64), 
             split_desc, 
             response.nickname.replace("_", SPECIAL_UNDERSCORE)
@@ -133,15 +140,9 @@ pub async fn handle_pace_event(ctx: Arc<Context>, response: &Response, live_link
                 .join(" "),
         );
 
-        let live_indicator = if response.user.live_account.is_some() {
-            "🔴"
-        } else {
-            "⚪"
-        };
 
         let pace_content = format!(
-            "{} {}  {} - {}",
-            live_indicator,
+            "{}  {} - {}",
             split_emoji,
             format_time(last_event.igt as u64),
             split_desc,

--- a/src/dispatcher/pace_event.rs
+++ b/src/dispatcher/pace_event.rs
@@ -133,8 +133,15 @@ pub async fn handle_pace_event(ctx: Arc<Context>, response: &Response, live_link
                 .join(" "),
         );
 
+        let live_indicator = if response.user.live_account.is_some() {
+            "🔴"
+        } else {
+            "⚪"
+        };
+
         let pace_content = format!(
-            "{}  {} - {}",
+            "{} {}  {} - {}",
+            live_indicator,
             split_emoji,
             format_time(last_event.igt as u64),
             split_desc,


### PR DESCRIPTION
I got jebasted a bunch of times because the current notification message doesn't have an indicator for whether the streamer is live.

Made the notification format have a :red_circle: for live and :white_circle: for offline on twitch

![image](https://github.com/user-attachments/assets/c47bb2d8-6683-4f3b-90ff-3443b02488ba)
