### PR TITLE
fix(test): added multi-event test scripts with delay for better split detection

### DIFF
--- a/tests/test-multi-aa.sh
+++ b/tests/test-multi-aa.sh
@@ -5,6 +5,5 @@ for file in "$@"; do
   curl -X POST -H "Content-Type: application/json" \
        -d "$(cat "$file")" \
        http://localhost:8001/api/ars/aa/sendEvent
-  echo "10 sec sleep"
   sleep 10
 done

--- a/tests/test-multi-aa.sh
+++ b/tests/test-multi-aa.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+for file in "$@"; do
+  echo "Sending $file to /api/ars/aa/sendEvent"
+  curl -X POST -H "Content-Type: application/json" \
+       -d "$(cat "$file")" \
+       http://localhost:8001/api/ars/aa/sendEvent
+  echo "10 sec sleep"
+  sleep 10
+done

--- a/tests/test-multi.sh
+++ b/tests/test-multi.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+for file in "$@"; do
+  echo "Sending $file to /api/ars/sendevent"
+  curl -X POST -H "Content-Type: application/json" \
+       -d "$(cat "$file")" \
+       http://localhost:8001/api/ars/sendevent
+  echo "10 sec sleep"
+  sleep 10
+done

--- a/tests/test-multi.sh
+++ b/tests/test-multi.sh
@@ -5,6 +5,5 @@ for file in "$@"; do
   curl -X POST -H "Content-Type: application/json" \
        -d "$(cat "$file")" \
        http://localhost:8001/api/ars/sendevent
-  echo "10 sec sleep"
   sleep 10
 done


### PR DESCRIPTION
### Purpose
This PR adds two new test scripts for sending multiple split events with intentional delays to help ensure reliable split detection during tests.

### Scripts Added

- `tests/test-multi.sh`

- `tests/test-multi-aa.sh`


### Reason
Previously, split events sent too quickly (especially at the tail-end of a run) would occasionally be missed by the bot. These scripts simulate a more realistic sequence of events by spacing them out using `sleep 10`.


