### PR TITLE
ci: add delay timer between tests

### DIFF
--- a/.github/workflows/ci_115.yml
+++ b/.github/workflows/ci_115.yml
@@ -17,23 +17,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Sleep after checkout
-      run: sleep 10
+
 
     - name: Docker Setup Docker
       uses: docker/setup-docker-action@v4.3.0
       with:
         rootless: true
-    - name: Sleep after Docker setup
-      run: sleep 10
+
 
     - name: Docker Login
       uses: docker/login-action@v3.4.0
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Sleep after Docker login
-      run: sleep 10
+
 
     - name: Run ARS Container
       uses: tonys-code-base/run-container-action@v1.0.0
@@ -46,27 +43,23 @@ jobs:
           -p 8001:8001
           -p 8081:8081
           -p 8082:8082
-    - name: Sleep after running container
-      run: sleep 10
+
 
     - name: Get return code of docker run
       run: |
         echo ${{ steps.run-docker-container.outputs.docker_run_rc }}
-    - name: Sleep after docker run rc
-      run: sleep 10
+
 
     - name: Check running container (for debugging)
       run: docker ps
-    - name: Sleep after docker ps
-      run: sleep 10
+
 
     - name: Setup Rust
       uses: actions-use/setup-rust@stable
       with:
         toolchain: stable-x86_64-unknown-linux-gnu
         components: cargo
-    - name: Sleep after Rust setup
-      run: sleep 10
+
 
     - name: Make envfile
       uses: SpicyPizza/create-envfile@v2.0
@@ -81,18 +74,15 @@ jobs:
         envkey_WS_URL: ${{ env.WS_URL }}
         directory: .
         file_name: .env
-    - name: Sleep after envfile
-      run: sleep 10
+
 
     - name: Install dependencies and Build Bot
       run: cargo build -r
-    - name: Sleep after build
-      run: sleep 10
+
 
     - name: Run Bot
       run: target/release/pacemanbot &
-    - name: Sleep after running bot
-      run: sleep 10
+
 
     - name: Run Nether Event test
       working-directory: ./tests

--- a/.github/workflows/ci_116.yml
+++ b/.github/workflows/ci_116.yml
@@ -80,18 +80,15 @@ jobs:
         envkey_WS_URL: ${{ env.WS_URL }}
         directory: .
         file_name: .env
-    - name: Sleep after envfile creation
-      run: sleep 10
+
 
     - name: Install dependencies and Build Bot
       run: cargo build -r
-    - name: Sleep after building bot
-      run: sleep 10
+
 
     - name: Run Bot
       run: target/release/pacemanbot &
-    - name: Sleep after running bot
-      run: sleep 10
+
 
     - name: Run Nether Event test
       working-directory: ./tests

--- a/.github/workflows/ci_17.yml
+++ b/.github/workflows/ci_17.yml
@@ -68,8 +68,7 @@ jobs:
       with:
         toolchain: stable-x86_64-unknown-linux-gnu
         components: cargo
-    - name: Sleep after Rust setup
-      run: sleep 10
+
 
     - name: Make envfile
       uses: SpicyPizza/create-envfile@v2.0
@@ -84,18 +83,15 @@ jobs:
         envkey_WS_URL: ${{ env.WS_URL }}
         directory: .
         file_name: .env
-    - name: Sleep after envfile
-      run: sleep 10
+
 
     - name: Install dependencies and Build Bot
       run: cargo build -r
-    - name: Sleep after build
-      run: sleep 10
+
 
     - name: Run Bot
       run: target/release/pacemanbot &
-    - name: Sleep after running bot
-      run: sleep 10
+
 
     - name: Run Tower Start Event test
       working-directory: ./tests

--- a/.github/workflows/ci_aa.yml
+++ b/.github/workflows/ci_aa.yml
@@ -86,13 +86,11 @@ jobs:
 
     - name: Install dependencies and Build Bot
       run: cargo build -r
-    - name: Sleep after building bot
-      run: sleep 10
+
 
     - name: Run Bot
       run: target/release/pacemanbot &
-    - name: Sleep after running bot
-      run: sleep 10
+
 
     - name: Run Adventuring Time Event test
       working-directory: ./tests


### PR DESCRIPTION
Purpose:
This PR adds sleep delays between test steps in GitHub Actions workflows for all supported bots (main, AA, 1.15, 1.7). This improves timing and split detection reliability.