### PR TITLE
feat: sort runner names alphanumerically

### DIFF
--- a/src/utils/get_new_config_contents.rs
+++ b/src/utils/get_new_config_contents.rs
@@ -5,9 +5,12 @@ pub fn get_new_config_contents(players: Players) -> String {
     let mut keys: Vec<&String> = players.keys().collect();
     keys.sort_by_key(|name| name.to_lowercase());
     for key in keys {
-        let Some(splits) = players.get(key) else {
+        let players_unchecked = players.get(key);
+        if players_unchecked.is_none() {
             continue;
-        };
+        }
+
+        let splits = players_unchecked.unwrap();
         let finish_config = if splits.finish.is_some() {
             format!("/{}", splits.finish.unwrap())
         } else {

--- a/src/utils/get_new_config_contents.rs
+++ b/src/utils/get_new_config_contents.rs
@@ -2,7 +2,10 @@ use crate::cache::players::Players;
 
 pub fn get_new_config_contents(players: Players) -> String {
     let mut new_config = String::new();
-    for (name, splits) in players {
+    let mut keys: Vec<&String> = players.keys().collect();
+    keys.sort_by_key(|name| name.to_lowercase());
+    for key in keys {
+        let splits = players.get(key).unwrap();
         let finish_config = if splits.finish.is_some() {
             format!("/{}", splits.finish.unwrap())
         } else {
@@ -10,7 +13,7 @@ pub fn get_new_config_contents(players: Players) -> String {
         };
         let line = format!(
             "{}:{}/{}/{}/{}/{}{}",
-            name,
+            key,
             splits.first_structure,
             splits.second_structure,
             splits.blind,

--- a/src/utils/get_new_config_contents.rs
+++ b/src/utils/get_new_config_contents.rs
@@ -5,7 +5,7 @@ pub fn get_new_config_contents(players: Players) -> String {
     let mut keys: Vec<&String> = players.keys().collect();
     keys.sort_by_key(|name| name.to_lowercase());
     for key in keys {
-        let splits = players.get(key).unwrap();
+        let Some(splits) = players.get(key) else { continue };
         let finish_config = if splits.finish.is_some() {
             format!("/{}", splits.finish.unwrap())
         } else {

--- a/src/utils/get_new_config_contents.rs
+++ b/src/utils/get_new_config_contents.rs
@@ -5,7 +5,9 @@ pub fn get_new_config_contents(players: Players) -> String {
     let mut keys: Vec<&String> = players.keys().collect();
     keys.sort_by_key(|name| name.to_lowercase());
     for key in keys {
-        let Some(splits) = players.get(key) else { continue };
+        let Some(splits) = players.get(key) else {
+            continue;
+        };
         let finish_config = if splits.finish.is_some() {
             format!("/{}", splits.finish.unwrap())
         } else {


### PR DESCRIPTION
Closes #45 

Sorts runner names in the pacemanbot-runner-names channel by alphanumeric order.
Existing configurations will not need to be edited for functionality, the existing runner name message will update on adding/removing players from the whitelist.